### PR TITLE
rockpro64: IEP driver

### DIFF
--- a/patch/kernel/archive/rockchip64-6.19/general-v4l2-iep-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.19/general-v4l2-iep-driver.patch
@@ -1,80 +1,31 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Paolo <paolo.sabatino@gmail.com>
-Date: Thu, 9 Sep 2021 22:59:12 +0200
-Subject: Rockchip IEP driver
+From a420482aa6eb1cfda0530e3cfeee8447b1255fec Mon Sep 17 00:00:00 2001
+From: Fabian Wolter <github@fabian-wolter.de>
+Date: Sat, 20 Dec 2025 13:05:56 +0100
+Subject: [PATCH] Rockchip IEP driver
 
-> X-Git-Archeology: - Revision 4425589e15c3b1593731703c379df0fa1b4432fb: https://github.com/armbian/build/commit/4425589e15c3b1593731703c379df0fa1b4432fb
-> X-Git-Archeology:   Date: Thu, 09 Sep 2021 22:59:12 +0200
-> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
-> X-Git-Archeology:   Subject: rk322x: bump edge kernel to 5.14, u-boot to 2021.07 (#3133)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision a1d044de8e0bb6ca504386bc31f5615a9d169067: https://github.com/armbian/build/commit/a1d044de8e0bb6ca504386bc31f5615a9d169067
-> X-Git-Archeology:   Date: Tue, 12 Oct 2021 15:59:01 +0200
-> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
-> X-Git-Archeology:   Subject: rockchip: update support for edge kernel 5.14
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 682e4085ab8faa278db21a41ed23a6b12f8868ea: https://github.com/armbian/build/commit/682e4085ab8faa278db21a41ed23a6b12f8868ea
-> X-Git-Archeology:   Date: Thu, 21 Oct 2021 22:55:25 +0200
-> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
-> X-Git-Archeology:   Subject: rockchip64: add IEP driver (#3215)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
-> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
-> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
-> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
-> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
-> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
-> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
-> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
-> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
-> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
-> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
-> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
-> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
-> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
-> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
-> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
-> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
-> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
-> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
-> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
-> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
-> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
-> X-Git-Archeology:
-> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
-> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
-> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
-> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
-> X-Git-Archeology:
 ---
- Documentation/devicetree/bindings/media/rockchip-iep.yaml |   73 +
- arch/arm/boot/dts/rockchip/rk3288.dtsi                    |   13 +-
- arch/arm64/boot/dts/rockchip/rk3328.dtsi                  |   22 +
- arch/arm64/boot/dts/rockchip/rk3399-base.dtsi             |   13 +
- drivers/media/platform/rockchip/Kconfig                   |    1 +
- drivers/media/platform/rockchip/Makefile                  |    1 +
- drivers/media/platform/rockchip/iep/Kconfig               |   13 +
- drivers/media/platform/rockchip/iep/Makefile              |    5 +
- drivers/media/platform/rockchip/iep/iep-regs.h            |  291 +++
- drivers/media/platform/rockchip/iep/iep.c                 | 1089 ++++++++++
- drivers/media/platform/rockchip/iep/iep.h                 |  112 +
- 11 files changed, 1632 insertions(+), 1 deletion(-)
+ .../bindings/media/rockchip-iep.yaml          |   73 ++
+ arch/arm/boot/dts/rockchip/rk3288.dtsi        |   13 +-
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi      |   22 +
+ arch/arm64/boot/dts/rockchip/rk3399-base.dtsi |   13 +-
+ drivers/media/platform/rockchip/Kconfig       |    1 +
+ drivers/media/platform/rockchip/Makefile      |    1 +
+ drivers/media/platform/rockchip/iep/Kconfig   |   16 +
+ drivers/media/platform/rockchip/iep/Makefile  |    5 +
+ .../media/platform/rockchip/iep/iep-regs.h    |  291 +++++
+ drivers/media/platform/rockchip/iep/iep.c     | 1087 +++++++++++++++++
+ drivers/media/platform/rockchip/iep/iep.h     |  112 ++
+ 11 files changed, 1632 insertions(+), 2 deletions(-)
+ create mode 100644 Documentation/devicetree/bindings/media/rockchip-iep.yaml
+ create mode 100644 drivers/media/platform/rockchip/iep/Kconfig
+ create mode 100644 drivers/media/platform/rockchip/iep/Makefile
+ create mode 100644 drivers/media/platform/rockchip/iep/iep-regs.h
+ create mode 100644 drivers/media/platform/rockchip/iep/iep.c
+ create mode 100644 drivers/media/platform/rockchip/iep/iep.h
 
 diff --git a/Documentation/devicetree/bindings/media/rockchip-iep.yaml b/Documentation/devicetree/bindings/media/rockchip-iep.yaml
 new file mode 100644
-index 000000000000..111111111111
+index 000000000..a9efcda13
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/media/rockchip-iep.yaml
 @@ -0,0 +1,73 @@
@@ -152,10 +103,10 @@ index 000000000000..111111111111
 +      power-domains = <&power RK3228_PD_VIO>;
 +    };
 diff --git a/arch/arm/boot/dts/rockchip/rk3288.dtsi b/arch/arm/boot/dts/rockchip/rk3288.dtsi
-index 111111111111..222222222222 100644
+index 42d705b54..773376166 100644
 --- a/arch/arm/boot/dts/rockchip/rk3288.dtsi
 +++ b/arch/arm/boot/dts/rockchip/rk3288.dtsi
-@@ -983,14 +983,25 @@ crypto: crypto@ff8a0000 {
+@@ -990,14 +990,25 @@ crypto: crypto@ff8a0000 {
  		reset-names = "crypto-rst";
  	};
  
@@ -183,7 +134,7 @@ index 111111111111..222222222222 100644
  
  	isp_mmu: iommu@ff914000 {
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 111111111111..222222222222 100644
+index 03b7c4313..d29e4843b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 @@ -784,6 +784,28 @@ vop_mmu: iommu@ff373f00 {
@@ -216,14 +167,13 @@ index 111111111111..222222222222 100644
  		compatible = "rockchip,rk3328-dw-hdmi";
  		reg = <0x0 0xff3c0000 0x0 0x20000>;
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-base.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-base.dtsi
-index 111111111111..222222222222 100644
+index 4dcceb913..0d40ac352 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-base.dtsi
-@@ -1475,12 +1475,25 @@ vdec_mmu: iommu@ff660480 {
+@@ -1475,14 +1475,25 @@ vdec_mmu: iommu@ff660480 {
  		#iommu-cells = <0>;
  	};
  
-+
 +	iep: iep@ff670000 {
 +		compatible = "rockchip,rk3399-iep", "rockchip,rk3228-iep";
 +		reg = <0x0 0xff670000 0x0 0x800>;
@@ -243,35 +193,44 @@ index 111111111111..222222222222 100644
  		clock-names = "aclk", "iface";
 +		power-domains = <&power RK3399_PD_IEP>;
  		#iommu-cells = <0>;
- 		status = "disabled";
+-		status = "disabled";
  	};
+ 
+ 	rga: rga@ff680000 {
 diff --git a/drivers/media/platform/rockchip/Kconfig b/drivers/media/platform/rockchip/Kconfig
-index 111111111111..222222222222 100644
+index 9bbeec499..6f8d6bee2 100644
 --- a/drivers/media/platform/rockchip/Kconfig
 +++ b/drivers/media/platform/rockchip/Kconfig
-@@ -6,3 +6,4 @@ source "drivers/media/platform/rockchip/rga/Kconfig"
- source "drivers/media/platform/rockchip/rkcif/Kconfig"
+@@ -2,6 +2,7 @@
+ 
+ comment "Rockchip media platform drivers"
+ 
++source "drivers/media/platform/rockchip/iep/Kconfig"
+ source "drivers/media/platform/rockchip/rga/Kconfig"
  source "drivers/media/platform/rockchip/rkisp1/Kconfig"
  source "drivers/media/platform/rockchip/rkvdec/Kconfig"
-+source "drivers/media/platform/rockchip/iep/Kconfig"
 diff --git a/drivers/media/platform/rockchip/Makefile b/drivers/media/platform/rockchip/Makefile
-index 111111111111..222222222222 100644
+index 286dc5c53..fc9110004 100644
 --- a/drivers/media/platform/rockchip/Makefile
 +++ b/drivers/media/platform/rockchip/Makefile
-@@ -3,3 +3,4 @@ obj-y += rga/
- obj-y += rkcif/
+@@ -1,4 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0-only
++obj-y += iep/
+ obj-y += rga/
  obj-y += rkisp1/
  obj-y += rkvdec/
-+obj-y += iep/
 diff --git a/drivers/media/platform/rockchip/iep/Kconfig b/drivers/media/platform/rockchip/iep/Kconfig
 new file mode 100644
-index 000000000000..111111111111
+index 000000000..d95155a95
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/Kconfig
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,16 @@
++# SPDX-License-Identifier: GPL-2.0-only
++ 
 +config VIDEO_ROCKCHIP_IEP
 +	tristate "Rockchip Image Enhancement Processor"
-+	depends on VIDEO_DEV && VIDEO_V4L2
++	depends on V4L_MEM2MEM_DRIVERS
++	depends on VIDEO_DEV
 +	depends on ARCH_ROCKCHIP || COMPILE_TEST
 +	select VIDEOBUF2_DMA_CONTIG
 +	select V4L2_MEM2MEM_DEV
@@ -284,7 +243,7 @@ index 000000000000..111111111111
 +	  will be called rockchip-iep
 diff --git a/drivers/media/platform/rockchip/iep/Makefile b/drivers/media/platform/rockchip/iep/Makefile
 new file mode 100644
-index 000000000000..111111111111
+index 000000000..5c89b3277
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/Makefile
 @@ -0,0 +1,5 @@
@@ -295,7 +254,7 @@ index 000000000000..111111111111
 +obj-$(CONFIG_VIDEO_ROCKCHIP_IEP) += rockchip-iep.o
 diff --git a/drivers/media/platform/rockchip/iep/iep-regs.h b/drivers/media/platform/rockchip/iep/iep-regs.h
 new file mode 100644
-index 000000000000..111111111111
+index 000000000..a68685ef3
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/iep-regs.h
 @@ -0,0 +1,291 @@
@@ -592,10 +551,10 @@ index 000000000000..111111111111
 +#endif
 diff --git a/drivers/media/platform/rockchip/iep/iep.c b/drivers/media/platform/rockchip/iep/iep.c
 new file mode 100644
-index 000000000000..111111111111
+index 000000000..165a61c9a
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/iep.c
-@@ -0,0 +1,1089 @@
+@@ -0,0 +1,1087 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Rockchip Image Enhancement Processor (IEP) driver
@@ -850,7 +809,7 @@ index 000000000000..111111111111
 +	addr = vb2_dma_contig_plane_dma_addr(&dst->vb2_buf, 0);
 +
 +	if (IEP_DEIN_OUT_MODE_FRAMES(dein_mode) == IEP_DEIN_OUT_FRAMES_2) {
-+		v4l2_m2m_buf_copy_metadata(ctx->prev_src_buf, dst, true);
++		v4l2_m2m_buf_copy_metadata(ctx->prev_src_buf, dst);
 +
 +		iep_write(iep, IEP_DEIN_OUT_IMG0_Y(ctx->field_bff), addr);
 +
@@ -866,7 +825,7 @@ index 000000000000..111111111111
 +		addr = vb2_dma_contig_plane_dma_addr(&dst->vb2_buf, 0);
 +	}
 +
-+	v4l2_m2m_buf_copy_metadata(src, dst, true);
++	v4l2_m2m_buf_copy_metadata(src, dst);
 +
 +	iep_write(iep, IEP_DEIN_OUT_IMG1_Y(ctx->field_bff), addr);
 +
@@ -1055,7 +1014,7 @@ index 000000000000..111111111111
 +	src_vq->io_modes = VB2_MMAP | VB2_DMABUF;
 +	src_vq->drv_priv = ctx;
 +	src_vq->buf_struct_size = sizeof(struct v4l2_m2m_buffer);
-+	src_vq->min_buffers_needed = 1;
++	src_vq->min_queued_buffers = 1;
 +	src_vq->ops = &iep_qops;
 +	src_vq->mem_ops = &vb2_dma_contig_memops;
 +	src_vq->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_COPY;
@@ -1072,7 +1031,7 @@ index 000000000000..111111111111
 +	dst_vq->io_modes = VB2_MMAP | VB2_DMABUF;
 +	dst_vq->drv_priv = ctx;
 +	dst_vq->buf_struct_size = sizeof(struct v4l2_m2m_buffer);
-+	dst_vq->min_buffers_needed = 2;
++	dst_vq->min_queued_buffers = 2;
 +	dst_vq->ops = &iep_qops;
 +	dst_vq->mem_ops = &vb2_dma_contig_memops;
 +	dst_vq->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_COPY;
@@ -1167,7 +1126,7 @@ index 000000000000..111111111111
 +		goto err_free;
 +	}
 +
-+	v4l2_fh_add(&ctx->fh);
++	v4l2_fh_add(&ctx->fh, file);
 +
 +	mutex_unlock(&iep->mutex);
 +
@@ -1188,7 +1147,7 @@ index 000000000000..111111111111
 +
 +	mutex_lock(&iep->mutex);
 +
-+	v4l2_fh_del(&ctx->fh);
++	v4l2_fh_del(&ctx->fh, file);
 +	v4l2_fh_exit(&ctx->fh);
 +	v4l2_m2m_ctx_release(ctx->fh.m2m_ctx);
 +	kfree(ctx);
@@ -1614,8 +1573,6 @@ index 000000000000..111111111111
 +	v4l2_m2m_release(iep->m2m_dev);
 +	video_unregister_device(&iep->vfd);
 +	v4l2_device_unregister(&iep->v4l2_dev);
-+
-+	return;
 +}
 +
 +static int __maybe_unused iep_runtime_suspend(struct device *dev)
@@ -1687,7 +1644,7 @@ index 000000000000..111111111111
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/platform/rockchip/iep/iep.h b/drivers/media/platform/rockchip/iep/iep.h
 new file mode 100644
-index 000000000000..111111111111
+index 000000000..7d9fc6162
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/iep.h
 @@ -0,0 +1,112 @@
@@ -1804,5 +1761,5 @@ index 000000000000..111111111111
 +
 +#endif
 -- 
-Armbian
+2.43.0
 


### PR DESCRIPTION
`v4l2_m2m_buf_copy_metadata()` needed to be adjusted for 6.19 compared to 6.18 from armbian/build#9107.